### PR TITLE
Remove default features from reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
 lazy_static = "1.4"
 http = "0.2"
 tokio = "1.45.1"


### PR DESCRIPTION
### Configure `Cargo.toml` to compile `reqwest` 0.11 with `default-features = false` and only the `blocking` and `json` features
Updates the dependency manifest to set an explicit feature set for `reqwest` by disabling defaults and enabling `blocking` and `json` in [Cargo.toml](https://github.com/ephemeraHQ/toxiproxy_rust/pull/1/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542).

#### 📍Where to Start
Start with the `reqwest` dependency entry in [Cargo.toml](https://github.com/ephemeraHQ/toxiproxy_rust/pull/1/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542).

----

_[Macroscope](https://app.macroscope.com) summarized 3b6e725._